### PR TITLE
feat(gatsby-site): Add design tokens CSS vars

### DIFF
--- a/frameworks/gatsby-site/src/components/Animals.tsx
+++ b/frameworks/gatsby-site/src/components/Animals.tsx
@@ -9,9 +9,10 @@ const AnimalList = styled.section`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  margin: 32px 0;
-  gap: 64px;
-  // justify-content: space-between;
+  margin: var(--size-5) 0;
+  padding-bottom: var(--size-5);
+  gap: var(--size-6);
+  justify-content: space-between;
 `;
 
 const Card = styled.div`
@@ -20,10 +21,11 @@ const Card = styled.div`
   align-self: flex-start;
   overflow: hidden;
   box-sizing: content-box;
-  font-size: 14px;
-  color: #66333370;
-  line-height: 1.5;
+  font-size: var(--font-size-1);
+  color: var(--color-text-calm);
+  line-height: var(--line-height-3);
   position: relative;
+
   @media only screen and (max-width: 500px) {
     width: 100%;
     flex: auto;
@@ -37,7 +39,8 @@ const AnimalImage = styled.img`
   object-fit: cover;
   height: 200px;
   display: inherit;
-  border-radius: 16px;
+  border-radius: var(--radius-5);
+
   @media only screen and (max-width: 500px) {
     width: 100%;
     height: 200px;
@@ -45,38 +48,38 @@ const AnimalImage = styled.img`
 `;
 
 const AnimalName = styled.p`
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 1.25;
-  color: #663;
+  font-size: var(--font-size-2);
+  font-weight: var(--font-weight-7);
+  line-height: var(--lineheight-1);
+  color: var(--color-text);
   margin: 12px 0 0;
   display: inline-block;
 `;
 
 const AnimalType = styled.span`
-  font-size: 12px;
-  line-height: 1;
-  color: #666633a0;
-  background: #66333310;
-  padding: 6px 8px;
-  border-radius: 1000px;
+  font-size: var(--font-size-0);
+  line-height: var(--lineheight-0);
+  color: var(--color-text-calm);
+  background: var(--color-text-light);
+  padding: 6px var(--size-2);
+  border-radius: var(--radius-100);
   text-transform: capitalize;
   float: right;
   margin: 12px 0 0;
 `;
 
 const ViewDetails = styled(Link)`
-  font-weight: 600;
-  color: #66333380;
-  line-height: 1;
+  font-weight: var(--font-weight-6);
+  color: var(--color-text-calm);
+  line-height: var(--lineheight-00);
   text-underline-offset: 2px;
-  margin: 24px 0 0;
+  margin: var(--size-4) 0 0;
   display: flex;
   align-items: baseline;
   text-decoration: none;
 
   :hover {
-    color: #ff6566;
+    color: var(--color-active);
     text-decoration: underline;
   }
 
@@ -94,8 +97,8 @@ const ViewDetails = styled(Link)`
 const ViewDetailsIcon = styled.span`
   text-decoration: none;
   display: inline-block;
-  width: 16px;
-  height: 16px;
+  width: var(--size-3);
+  height: var(--size-3);
 
   > svg {
     vertical-align: middle;
@@ -113,9 +116,9 @@ const ChevronRight = () => (
     <path
       d="M9 18L15 12L9 6"
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );

--- a/frameworks/gatsby-site/src/components/GlobalStyles.tsx
+++ b/frameworks/gatsby-site/src/components/GlobalStyles.tsx
@@ -1,0 +1,78 @@
+import { createGlobalStyle } from "styled-components";
+
+const GlobalStyles = createGlobalStyle`
+  html {
+    --size-1: 4px;
+    --size-2: 8px;
+    --size-3: 16px;
+    --size-4: 24px;
+    --size-5: 32px;
+    --size-6: 48px;
+    --size-7: 64px;
+
+    --color-text:            #663333;
+    --color-text-calm:       #66333380;
+    --color-text-light:      #66663310;
+    --color-text-lighter:    #6633330f;
+
+    --color-background:      #ffffff;
+    --color-on-emphasis:     #ffffff;
+    --color-background-rgb:  255, 255, 255;
+
+    --color-primary:         rebeccapurple;
+    --color-gatsby:          #7026b9;
+    --color-active:          #ff6566;
+    --color-active-light:    #ff656610;
+
+
+    --font-sans: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+    
+    --lineheight-00: 1;
+    --lineheight-0: 1.1;
+    --lineheight-1: 1.25;
+    --lineheight-2: 1.375;
+    --lineheight-3: 1.5;
+    --lineheight-4: 1.75;
+    --lineheight-5: 2;
+
+    --font-size-00: .5rem;
+    --font-size-0: .75rem;
+    --font-size-1: .875rem;
+    --font-size-2: 1rem;
+    --font-size-3: 1.125rem;
+    --font-size-4: 1.25rem;
+    --font-size-5: 1.5rem;
+    --font-size-6: 2rem;
+
+    --font-weight-1: 100;
+    --font-weight-2: 200;
+    --font-weight-3: 300;
+    --font-weight-4: 400;
+    --font-weight-5: 500;
+    --font-weight-6: 600;
+    --font-weight-7: 700;
+    --font-weight-8: 800;
+    --font-weight-9: 900;
+
+    --radius-1: 2px;
+    --radius-2: 4px;
+    --radius-3: 6px;
+    --radius-4: 8px;
+    --radius-5: 16px;
+    --radius-100: 9999px;
+
+
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    line-height: var(--lineheight-3);
+
+    input,
+    button {
+      color: var(--color-text);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+    }
+}
+`;
+
+export default GlobalStyles;

--- a/frameworks/gatsby-site/src/components/Layout.tsx
+++ b/frameworks/gatsby-site/src/components/Layout.tsx
@@ -4,53 +4,61 @@ import styled from "styled-components";
 import "@fontsource/inter";
 
 import logo from "../assets/logo.svg";
+import GlobalStyles from "./GlobalStyles";
 
 const PageWrapper = styled.div`
-  color: #232129;
   max-width: 1024px;
-  margin: 32px auto 64px;
-  padding: 0 32px;
-  font-family: Inter, Roboto, "sans-serif";
+  margin: var(--size-5) auto var(--size-6);
+  padding: 0 var(--size-5);
 `;
 
 const Navbar = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 32px;
-  @media only screen and (max-width: 500px) {
-    margin-bottom: 32px;
+  margin-bottom: var(--size-5);
+`;
+
+const HomeLink = styled(Link)`
+  text-decoration: none;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  align-items: flex-end;
+  transition-property: transform;
+  transition-duration: 0.15s;
+  transition-timing-function: ease-in-out;
+
+  :hover {
+    transform: scale(1.1);
   }
 `;
 
-const FlexItem = styled.div`
-  display: flex;
-`;
-
-const PupLogo = styled.img`
-  height: 48px;
-  width: 48px;
+const Logo = styled.img`
+  height: var(--size-6);
+  width: var(--size-6);
 `;
 
 const NavTitle = styled.h1`
-  color: #633;
-  font-size: 18px;
-  line-height: 1;
+  alignself: flex-end;
+  color: var(--color-text);
+  font-size: var(--font-size-3);
+  line-height: var(--lineheight-00);
   margin: 0;
 `;
 
 const PoweredBy = styled.p`
-  font-size: 14px;
+  font-size: var(--font-size-1);
   margin: 0;
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: var(--size-2);
 `;
 
 const PoweredByLink = styled.a`
-  font-weight: 600;
-  color: #7026b9;
+  font-weight: var(--font-weight-6);
+  color: var(--color-gatsby);
   text-decoration: none;
   display: inline-flex;
   flex-direction: row;
@@ -80,31 +88,32 @@ const GatsbyIcon = (
 
 export function Layout({ children, isDogs, active }) {
   return (
-    <PageWrapper>
-      <Navbar>
-        <Link to="/" style={{ textDecoration: "none" }}>
-          <FlexItem style={{ flexDirection: `row`, gap: 12 }}>
-            <PupLogo src={logo} alt="Pet Snuggles" />
-            <NavTitle style={{ alignSelf: "flex-end" }}>
+    <>
+      <GlobalStyles />
+      <PageWrapper>
+        <Navbar>
+          <HomeLink to="/">
+            <Logo src={logo} alt="Pet Snuggles" />
+            <NavTitle>
               Pet
               <br />
               Snuggles
             </NavTitle>
-          </FlexItem>
-        </Link>
-        <PoweredBy>
-          Powered by{" "}
-          <PoweredByLink
-            href="https://www.gatsbyjs.com/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            {GatsbyIcon}
-            Gatsby
-          </PoweredByLink>
-        </PoweredBy>
-      </Navbar>
-      <div>{children}</div>
-    </PageWrapper>
+          </HomeLink>
+          <PoweredBy>
+            Powered by{" "}
+            <PoweredByLink
+              href="https://www.gatsbyjs.com/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {GatsbyIcon}
+              Gatsby
+            </PoweredByLink>
+          </PoweredBy>
+        </Navbar>
+        <div>{children}</div>
+      </PageWrapper>
+    </>
   );
 }

--- a/frameworks/gatsby-site/src/pages/404.tsx
+++ b/frameworks/gatsby-site/src/pages/404.tsx
@@ -1,54 +1,43 @@
-import * as React from "react"
-import { Link } from "gatsby"
+import * as React from "react";
+import { Link } from "gatsby";
+import styled from "styled-components";
 
-// styles
-const pageStyles = {
-  color: "#232129",
-  padding: "96px",
-  fontFamily: "-apple-system, Roboto, sans-serif, serif",
-}
-const headingStyles = {
-  marginTop: 0,
-  marginBottom: 64,
-  maxWidth: 320,
-}
+import { Layout } from "../components/Layout";
 
-const paragraphStyles = {
-  marginBottom: 48,
-}
-const codeStyles = {
-  color: "#8A6534",
-  padding: 4,
-  backgroundColor: "#FFF4DB",
-  fontSize: "1.25rem",
-  borderRadius: 4,
-}
+const Main = styled.main``;
 
-// markup
+const Heading = styled.h1`
+  margin: var(--size-7) 0 var(--size-3);
+  font-size: var(--font-size-4);
+  line-height: var(--lineheight-00);
+`;
+
+const P = styled.p`
+  margin-bottom: var(--size-6);
+`;
+
 const NotFoundPage = () => {
   return (
-    <main style={pageStyles}>
-      <title>Not found</title>
-      <h1 style={headingStyles}>Page not found</h1>
-      <p style={paragraphStyles}>
-        Sorry{" "}
-        <span role="img" aria-label="Pensive emoji">
-          😔
-        </span>{" "}
-        we couldn’t find what you were looking for.
-        <br />
-        {process.env.NODE_ENV === "development" ? (
-          <>
-            <br />
-            Try creating a page in <code style={codeStyles}>src/pages/</code>.
-            <br />
-          </>
-        ) : null}
-        <br />
-        <Link to="/">Go home</Link>.
-      </p>
-    </main>
-  )
-}
+    <Layout>
+      <Main>
+        <title>404 not found</title>
+        <Heading>
+          404
+          <br />
+          page not found
+        </Heading>
+        <P>
+          We're sorry{" "}
+          <span role="img" aria-label="Pensive emoji">
+            😔
+          </span>
+          , but we couldn’t find what you were looking for.
+          <br />
+          <Link to="/">Go home</Link>.
+        </P>
+      </Main>
+    </Layout>
+  );
+};
 
-export default NotFoundPage
+export default NotFoundPage;

--- a/frameworks/gatsby-site/src/pages/[type]/[id].tsx
+++ b/frameworks/gatsby-site/src/pages/[type]/[id].tsx
@@ -4,14 +4,15 @@ import { Layout } from "../../components/Layout";
 import { AnimalDisplay } from "../../components/Animals";
 
 const Card = styled.div`
-  background: #ffffff;
-  border-radius: 8px;
+  background: var(--color-background);
+  border-radius: var(--radius-4);
   max-width: 640px;
-  margin: 24px auto;
+  margin: var(--size-4) auto;
   align-self: center;
   overflow: hidden;
-  padding: 20px;
+  padding: var(--size-4);
   box-sizing: content-box;
+
   @media only screen and (max-width: 500px) {
     width: 100%;
     flex: auto;

--- a/frameworks/gatsby-site/src/pages/index.tsx
+++ b/frameworks/gatsby-site/src/pages/index.tsx
@@ -15,114 +15,118 @@ const FilterAndSearch = styled.div`
   z-index: 1;
   background-image: linear-gradient(
     to bottom,
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0.95)
+    rgba(var(--color-background-rgb), 1),
+    rgba(var(--color-background-rgb), 0.95)
   );
 `;
 
 const Filters = styled.div`
   display: flex;
-  margin: 32px 0;
-  gap: 16px;
+  margin: var(--size-5) 0;
+  gap: var(--size-3);
   align-items: center;
 `;
 
 const FilterButton = styled.button`
   background: transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-2);
   border: none;
-  font-size: 18px;
+  font-size: var(--font-size-3);
   cursor: pointer;
-  font-weight: 700;
-  color: #66333380;
-  font-family: Inter, sans-serif;
+  font-weight: var(--font-weight-7);
+  color: var(--color-text-calm);
 
   :hover {
-    color: #ff6566;
+    color: var(--color-active);
   }
 
   ${(props) =>
     props.active &&
     css`
-      color: #633;
+      color: var(--color-text);
     `}
 `;
 
 const SearchContainer = styled.div`
-  background: #6633330f;
-  border-radius: 6px;
+  background: var(--color-text-lighter);
+  border-radius: var(--radius-3);
   position: relative;
-  color: #66333380;
+  color: var(--color-text-calm);
 `;
 
 const Search = styled.input`
-  border-radius: 6px;
-  font-family: Inter, sans-serif;
-  font-size: 16px;
-  color: #633;
+  border-radius: var(--radius-3);
   border: none;
   background: none;
-  padding: 9px 16px 9px 36px;
+  padding: var(--size-2) var(--size-3) var(--size-2) 36px;
+  min-height: 40px;
 
   :placeholder {
-    color: #66333380;
+    color: var(--color-text-calm);
   }
 `;
 
+const SearchIconSvg = styled.svg`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: var(--size-2);
+`;
+
 const Pagination = styled.nav`
-  margin: 32px 0;
+  margin: var(--size-6) 0;
   display: flex;
   flex-direction: row;
-  gap: 16px;
+  gap: var(--size-3);
   list-style: none;
   padding: 0;
 `;
 
 const PaginationLink = styled(Link)`
-  border-radius: 4px;
+  border-radius: var(--radius-2);
   text-decoration: none;
-  font-weight: 500;
+  font-weight: var(--font-weight-5);
   position: relative;
   display: block;
-  padding: 8px 12px;
-  font-size: 14px;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  color: #663;
-  background: #66663310;
+  padding: var(--size-2) var(--size-3);
+  font-size: var(--font-size-2);
+  transition-property: color, background-color;
+  transition-duration: 0.15s;
+  transition-timing-function: ease-in-out;
+  color: var(--color-text);
+  background: var(--color-text-light);
 
   :hover {
-    background: #ff656610;
-    color: #ff6566;
+    background: var(--color-active-light);
+    color: var(--color-active);
   }
 
   ${(props) =>
     props.active &&
     css`
-      background: #ff6566;
-      color: #fff;
+      background: var(--color-active);
+      color: var(--color-on-emphasis);
     `}
 `;
 
 const SearchIcon = () => (
-  <svg
+  <SearchIconSvg
     width="20"
     height="20"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    style={{ position: "absolute", top: 8, left: 8 }}
   >
     <g
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     >
       <path d="M11 19.1758C15.4183 19.1758 19 15.5941 19 11.1758C19 6.7575 15.4183 3.17578 11 3.17578C6.58172 3.17578 3 6.7575 3 11.1758C3 15.5941 6.58172 19.1758 11 19.1758Z" />
       <path d="M21.0004 21.1742L16.6504 16.8242" />
     </g>
-  </svg>
+  </SearchIconSvg>
 );
 
 export default function Catalog({ data }) {


### PR DESCRIPTION
This will help a bunch for the new `/blog` pages: move all design tokens to CSS vars – cheapest WRT PR diff, probably not a huge difference WRT moving to whatever other CSS solution.

Tidy moar along the way:

- define `font-family` and `color` globally, also for `input` and `button`, for a bit more DRY
- ditch `Layout`'s `FlexItem`
- ditch `style` props
- no shorthand for CSS transitions, tidy copy-pasta
- add `Layout` to, and use `styled-components` for the 404 page
- fix SVG attribute warnings
- minor improvements to `<Pagination>`
- ditch `process.env.NODE_ENV === "development"`-specific conditional info on the 404 page