### PR TITLE
feat: Show framework, mention Valhalla in header

### DIFF
--- a/frameworks/astro/src/layouts/Layout.astro
+++ b/frameworks/astro/src/layouts/Layout.astro
@@ -28,33 +28,31 @@ const { title } = Astro.props;
           <a href="/store/" class="nav-link">Swag</a>
         </nav>
         <p class="powered-by">
-          Powered by{" "}
-          <a
-            class="powered-by-link"
-            href="https://www.gatsbyjs.com/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 28 28"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
+          <span>
+            Powered by{" "}
+            <a
+              class="powered-by-link"
+              href="https://www.gatsbyjs.com/"
+              target="_blank"
+              rel="noreferrer"
             >
-              <circle fill="#7026B9" cx="14" cy="14" r="14"></circle>
-              <g fill="#fff">
-                <path
-                  d="M6.2,21.8C4.1,19.7,3,16.9,3,14.2L13.9,25C11.1,24.9,8.3,23.9,6.2,21.8z"
-                ></path>
-                <path
-                  d="M16.4,24.7L3.3,11.6C4.4,6.7,8.8,3,14,3c3.7,0,6.9,1.8,8.9,4.5l-1.5,1.3C19.7,6.5,17,5,14,5
-				  c-3.9,0-7.2,2.5-8.5,6L17,22.5c2.9-1,5.1-3.5,5.8-6.5H18v-2h7C25,19.2,21.3,23.6,16.4,24.7z"
-                ></path>
-              </g>
-            </svg>
-            Gatsby
-          </a>
+              Valhalla
+            </a>
+            and <b style={{ fontWeight: "var(--font-weight-6)" }}>Astro</b>
+          </span>
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M13.162 1.52486C12.9954 0.977552 12.9121 0.703909 12.7487 0.501125C12.6045 0.322098 12.4168 0.183034 12.2036 0.097213C11.962 0 11.676 0 11.1039 0H8.49155C7.92021 0 7.63455 0 7.39319 0.0970096C7.18012 0.182654 6.99254 0.321439 6.84833 0.50014C6.68497 0.702548 6.60142 0.975693 6.43433 1.52195L6.43429 1.52208H6.43427L2.77686 13.479C4.12826 12.7784 5.5978 12.2741 7.14772 12.0036L9.48876 4.0006C9.52721 3.86912 9.64779 3.77876 9.78479 3.77876C9.92141 3.77876 10.0418 3.86865 10.0805 3.99968L12.4503 12.0077C13.993 12.2793 15.4559 12.7828 16.8015 13.4809L13.162 1.52486ZM10.0076 14.9127C11.387 14.9127 12.5846 14.5628 13.1846 14.0498C13.2645 14.3006 13.3075 14.5678 13.3075 14.845C13.3075 15.2959 13.1936 15.72 12.9929 16.0905C12.6084 16.8003 12.0506 17.1541 11.5484 17.4726L11.5482 17.4727C10.917 17.8731 10.3739 18.2176 10.3739 19.1427C10.3739 19.45 10.4445 19.7409 10.5704 19.9999C9.72736 19.6493 9.13454 18.8178 9.13454 17.8479L9.13459 17.7909V17.7909C9.13541 17.1518 9.13643 16.3643 8.2336 16.3643C7.70687 16.3643 7.27986 16.7912 7.27986 17.3179C6.26544 16.3034 6.35414 14.845 6.35414 14.845C6.35414 14.548 6.38432 14.083 6.51894 13.6768C6.89549 14.3856 8.31455 14.9127 10.0076 14.9127Z"
+              fill="#663333"></path>
+          </svg>
         </p>
       </div>
 
@@ -63,17 +61,15 @@ const { title } = Astro.props;
     <style is:global>
       .powered-by-link {
         font-weight: var(--font-weight-6);
-        color: var(--color-gatsby);
-        text-decoration: none;
-        display: inline-flex;
-        flex-direction: row;
-        align-items: center;
-        align-self: center;
-        gap: 6px;
+        color: var(--color-text);
+        text-decoration: underline;
+        text-decoration-thickness: 1.5px;
+        text-underline-offset: 2px;
       }
       .powered-by {
-        font-size: var(--font-size-1);
-        margin: 0;
+        font-size: var(--font-size-2);
+        font-weight: var(--font-weight-5);
+        margin: 0 0 calc(-1 * var(--size-1));
         display: inline-flex;
         flex-direction: row;
         align-items: center;
@@ -122,7 +118,7 @@ const { title } = Astro.props;
       .navbar {
         display: flex;
         justify-content: space-between;
-        align-items: flex-start;
+        align-items: flex-end;
         margin-bottom: var(--size-5);
       }
       .page-wrapper {

--- a/frameworks/gatsby-site/src/components/Layout.tsx
+++ b/frameworks/gatsby-site/src/components/Layout.tsx
@@ -15,7 +15,7 @@ const PageWrapper = styled.div`
 const Navbar = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: flex-end;
   margin-bottom: var(--size-5);
 `;
 
@@ -68,8 +68,9 @@ const NavTitle = styled.h1`
 `;
 
 const PoweredBy = styled.p`
-  font-size: var(--font-size-1);
-  margin: 0;
+  font-size: var(--font-size-2);
+  font-weight: var(--font-weight-5);
+  margin: 0 0 calc(-1 * var(--size-1));
   display: inline-flex;
   flex-direction: row;
   align-items: center;
@@ -78,16 +79,13 @@ const PoweredBy = styled.p`
 
 const PoweredByLink = styled.a`
   font-weight: var(--font-weight-6);
-  color: var(--color-gatsby);
-  text-decoration: none;
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
-  align-self: center;
-  gap: 6px;
+  color: var(--color-text);
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 2px;
 `;
 
-const GatsbyIcon = (
+const FrameworkLogo = (
   <svg
     width="20"
     height="20"
@@ -95,7 +93,7 @@ const GatsbyIcon = (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <circle fill="#7026B9" cx="14" cy="14" r="14" />
+    <circle fill="#663333" cx="14" cy="14" r="14" />
     <g fill="#fff">
       <path d="M6.2,21.8C4.1,19.7,3,16.9,3,14.2L13.9,25C11.1,24.9,8.3,23.9,6.2,21.8z" />
       <path
@@ -126,15 +124,18 @@ export function Layout({ children, isDogs, active }) {
             <NavLink to="/store/">Swag</NavLink>
           </NavLinks>
           <PoweredBy>
-            Powered by{" "}
-            <PoweredByLink
-              href="https://www.gatsbyjs.com/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {GatsbyIcon}
-              Gatsby
-            </PoweredByLink>
+            <span>
+              Powered by{" "}
+              <PoweredByLink
+                href="https://www.gatsbyjs.com/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Valhalla
+              </PoweredByLink>{" "}
+              and <b style={{ fontWeight: "var(--font-weight-6)" }}>Gatsby</b>
+            </span>{" "}
+            {FrameworkLogo}
           </PoweredBy>
         </Navbar>
         <div>{children}</div>

--- a/frameworks/nextjs/pages/components/Layout.tsx
+++ b/frameworks/nextjs/pages/components/Layout.tsx
@@ -15,7 +15,7 @@ const PageWrapper = styled.div`
 const Navbar = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: flex-end;
   margin-bottom: var(--size-5);
 `;
 
@@ -68,8 +68,9 @@ const NavTitle = styled.h1`
 `;
 
 const PoweredBy = styled.p`
-  font-size: var(--font-size-1);
-  margin: 0;
+  font-size: var(--font-size-2);
+  font-weight: var(--font-weight-5);
+  margin: 0 0 calc(-1 * var(--size-1));
   display: inline-flex;
   flex-direction: row;
   align-items: center;
@@ -78,31 +79,24 @@ const PoweredBy = styled.p`
 
 const PoweredByLink = styled.a`
   font-weight: var(--font-weight-6);
-  color: var(--color-gatsby);
-  text-decoration: none;
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
-  align-self: center;
-  gap: 6px;
+  color: var(--color-text);
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 2px;
 `;
 
-const GatsbyIcon = (
+const FrameworkLogo = (
   <svg
     width="20"
     height="20"
-    viewBox="0 0 28 28"
+    viewBox="0 0 20 20"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <circle fill="#7026B9" cx="14" cy="14" r="14" />
-    <g fill="#fff">
-      <path d="M6.2,21.8C4.1,19.7,3,16.9,3,14.2L13.9,25C11.1,24.9,8.3,23.9,6.2,21.8z" />
-      <path
-        d="M16.4,24.7L3.3,11.6C4.4,6.7,8.8,3,14,3c3.7,0,6.9,1.8,8.9,4.5l-1.5,1.3C19.7,6.5,17,5,14,5
-			c-3.9,0-7.2,2.5-8.5,6L17,22.5c2.9-1,5.1-3.5,5.8-6.5H18v-2h7C25,19.2,21.3,23.6,16.4,24.7z"
-      />
-    </g>
+    <path
+      d="M9.34506 0.00538207C9.30205 0.00929157 9.1652 0.0229748 9.04203 0.0327485C6.20137 0.28882 3.54057 1.82134 1.85533 4.17681C0.916911 5.48649 0.316716 6.9721 0.0899316 8.54567C0.00977517 9.09496 0 9.2572 0 10.002C0 10.7467 0.00977517 10.909 0.0899316 11.4582C0.633431 15.2133 3.30596 18.3683 6.9306 19.5372C7.57967 19.7464 8.26393 19.8891 9.04203 19.9751C9.34506 20.0083 10.6549 20.0083 10.958 19.9751C12.3011 19.8265 13.4389 19.4942 14.5611 18.9215C14.7331 18.8335 14.7664 18.81 14.7429 18.7905C14.7273 18.7788 13.9941 17.7955 13.1144 16.607L11.5152 14.4471L9.51124 11.4817C8.4086 9.85144 7.50147 8.5183 7.49365 8.5183C7.48583 8.51635 7.47801 9.83385 7.4741 11.4426C7.46823 14.2594 7.46628 14.3728 7.43109 14.4392C7.38025 14.535 7.34115 14.5741 7.25904 14.6171C7.19648 14.6484 7.14174 14.6543 6.84653 14.6543H6.50831L6.41838 14.5976C6.35973 14.5604 6.31672 14.5116 6.28739 14.4549L6.24633 14.3669L6.25024 10.4476L6.25611 6.52642L6.31672 6.45018C6.348 6.40913 6.41447 6.35635 6.46139 6.33094C6.54154 6.29185 6.57282 6.28794 6.91105 6.28794C7.30987 6.28794 7.37634 6.30358 7.47996 6.41695C7.50929 6.44823 8.59433 8.0824 9.89247 10.0508C11.1906 12.0193 12.9658 14.707 13.8377 16.0265L15.4213 18.425L15.5015 18.3722C16.2111 17.9109 16.9619 17.2541 17.5562 16.5699C18.8211 15.1175 19.6364 13.3465 19.9101 11.4582C19.9902 10.909 20 10.7467 20 10.002C20 9.2572 19.9902 9.09496 19.9101 8.54567C19.3666 4.7906 16.694 1.63564 13.0694 0.466702C12.4301 0.259499 11.7498 0.116803 10.9873 0.0307938C10.7996 0.0112463 9.50733 -0.0102559 9.34506 0.00538207ZM13.4389 6.05337C13.5327 6.10028 13.609 6.1902 13.6364 6.28403C13.652 6.33485 13.6559 7.42169 13.652 9.87099L13.6461 13.3856L13.0264 12.4356L12.4047 11.4856V8.93076C12.4047 7.279 12.4125 6.35049 12.4242 6.30553C12.4555 6.19607 12.5239 6.11006 12.6178 6.05923C12.6979 6.01818 12.7273 6.01427 13.0342 6.01427C13.3236 6.01427 13.3744 6.01818 13.4389 6.05337Z"
+      fill="#663333"
+    />
   </svg>
 );
 
@@ -130,15 +124,18 @@ export function Layout({ children, isDogs, active }) {
             <NavLink href="/store/">Swag</NavLink>
           </NavLinks>
           <PoweredBy>
-            Powered by{" "}
-            <PoweredByLink
-              href="https://www.gatsbyjs.com/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {GatsbyIcon}
-              Gatsby
-            </PoweredByLink>
+            <span>
+              Powered by{" "}
+              <PoweredByLink
+                href="https://www.gatsbyjs.com/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Valhalla
+              </PoweredByLink>{" "}
+              and <b style={{ fontWeight: "var(--font-weight-6)" }}>Next.js</b>
+            </span>
+            {FrameworkLogo}
           </PoweredBy>
         </Navbar>
         <div>{children}</div>


### PR DESCRIPTION
Basic fix for https://app.shortcut.com/gatsbyjs/story/57282/pet-snuggles-show-framework-and-add-valhalla-logo

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/21834/197316319-117a1795-9eb5-4ed1-a50a-3e9db59f22d2.png">


