### PR TITLE
fix: link to Valhalla landing page

### DIFF
--- a/frameworks/astro/src/layouts/Layout.astro
+++ b/frameworks/astro/src/layouts/Layout.astro
@@ -34,7 +34,7 @@ const { title } = Astro.props;
             Powered by{" "}
             <a
               class="powered-by-link"
-              href="https://www.gatsbyjs.com/"
+              href="https://gatsby.dev/valhalla"
               target="_blank"
               rel="noreferrer"
             >

--- a/frameworks/gatsby/src/components/Layout.tsx
+++ b/frameworks/gatsby/src/components/Layout.tsx
@@ -32,7 +32,7 @@ export function Layout({ children }) {
           <span>
             Powered by{' '}
             <a
-              href="https://www.gatsbyjs.com/"
+              href="https://gatsby.dev/valhalla"
               target="_blank"
               rel="noreferrer"
               className={styles.poweredByLink}

--- a/frameworks/nextjs/app/layout.tsx
+++ b/frameworks/nextjs/app/layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({ children }) {
               <span>
                 Powered by{' '}
                 <a
-                  href="https://www.gatsbyjs.com/"
+                  href="https://gatsby.dev/valhalla"
                   target="_blank"
                   rel="noreferrer"
                   className={styles.poweredByLink}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21834/199644807-1f7b340e-3a03-4f23-8700-66bec5e1efde.png)

- instead of just to gatsbyjs.com
- using the short URL https://gatsbyjs.dev/valhalla that points to the final location of the landing page at https://www.gatsbyjs.com/products/valhalla-content-hub (page currently still at https://www.gatsbyjs.com/next/valhalla-content-hub/)